### PR TITLE
Removed reference to FreeBSD project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The views and conclusions contained in the software and documentation are those
 of the authors and should not be interpreted as representing official policies, 
-either expressed or implied, of the FreeBSD Project.
+either expressed or implied, of the gw2spidy project.
 
 
 Copyright and License - Apendix


### PR DESCRIPTION
Seems to just be a copy+paste mistake from the BSD license text.
