### PR TITLE
Fixed filtering on the recipe search view

### DIFF
--- a/templates/recipe_list.html.twig
+++ b/templates/recipe_list.html.twig
@@ -89,6 +89,7 @@
 
         <div class="form-horizontal" style="float: left; margin-top: -9px;">
             <form action="" method="GET">
+				{% if search is defined %}<input type="hidden" name="recipes" id="recipes" value="1" />{% endif %}
                 <div class="control-group">
                     <label class="control-label" for="min_level">Level:</label>
                     <div class="controls">


### PR DESCRIPTION
This fixes a bug with the filtering on search pages for recipes.

If you go to http://www.gw2spidy.com/search/banana?recipes=1 and hit "Filter" it will take you to the item page (http://www.gw2spidy.com/search/banana?min_level=0&max_level=10).
