### PR TITLE
Append a .0 to numbers in the range [1900,9999] if returning XML data to Excel.

### DIFF
--- a/src/GW2Spidy/API/APIHelperService.php
+++ b/src/GW2Spidy/API/APIHelperService.php
@@ -90,9 +90,9 @@ class APIHelperService {
         } else {
             // Excel 2013 has a FILTERXML function that auto-coerces integers between
             // [1900,9999] as dates, resulting in incorrect numbers. This adds a '.0'
-            // if the user agent is Excel/15*, to prevent that coercion.
-            if (is_integer($value) && $value >= 1900 && $value <= 9999 &&
-                    preg_match('/^Excel\/(15)/', $_SERVER['HTTP_USER_AGENT']))
+            // if specified, to prevent that coercion.
+            if (isset($_GET['excel_filterxml_fix']) && is_integer($value) &&
+                    $value >= 1900 && $value <= 9999)
                 $value .= '.0';
 
             $retval .= $value;


### PR DESCRIPTION
There is a bug in Microsoft Excel 2013's FILTERXML function, which causes
it to attempt to coerce numbers between [1900,9999] as dates. It then
returns their serial value (number of days since Jan 1st, 1900). This
coersion happens at a point where the user is unable to prevent it and
there is no known work around.

Luckily, when Excel 2013 requests data using its WEBSERVICE function, it
sets its user agent to Excel/15.0. We can thus check if Excel is downloading
data and if so, append a .0 to the end of numbers within that range. This
will prevent date coersion, and doesn't negatively impact the data, since
in Excel all numbers are floating points when doing calculations anyway.
