### PR TITLE
[WIP]Add Guild Wars 2 Oauth authentification

### DIFF
--- a/config/cnf/default.json
+++ b/config/cnf/default.json
@@ -24,13 +24,15 @@ cnf = {
 	 * hybrid auth config
 	 */
 	 "hybrid_auth" : {
-	 	"callback_url"    : "http://4gsd.localtunnel.com/hybridauth",
-	 	"google_id" 	  : "",
-	 	"google_secret"   : "",
-	 	"facebook_id" 	  : "",
-	 	"facebook_secret" : "",
-	 	"twitter_key" 	  : "",
-	 	"twitter_secret"  : ""
+		"callback_url"     : "http://localhost:8080/hybridauth",
+		"google_id" 	   : "",
+		"google_secret"    : "",
+		"facebook_id" 	   : "",
+		"facebook_secret"  : "",
+		"twitter_key" 	   : "",
+		"twitter_secret"   : "",
+		"guildwars_key"    : "",
+		"guildwars_secret" : ""
 	 },
 
     /*

--- a/config/hybridauth-config.php
+++ b/config/hybridauth-config.php
@@ -68,10 +68,15 @@ return
                 "enabled" => false,
                 "keys"    => array ( "id" => "", "secret" => "" )
             ),
+
+            "GuildWars" => array (
+                "enabled" => true,
+                "keys"    => array ( "id" => getAppConfig("hybrid_auth.guildwars_key"), "secret" => getAppConfig("hybrid_auth.guildwars_secret"))
+            )
         ),
 
         // if you want to enable logging, set 'debug_mode' to true  then provide a writable file by the web server on "debug_file"
-        "debug_mode" => false,
+        "debug_mode" => true,
 
         "debug_file" => "/tmp/hauth.log"
     );

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -18,6 +18,9 @@
                 <a href="{{ path('social_login', {'provider': 'google'}) }}" class="btn btn-large">
                     <i class="icon-google-plus"></i>
                 </a>
+                <a href="{{ path('social_login', {'provider': 'guildwars'}) }}" class="btn btn-large">
+                    <div>Guild Wars 2</div>
+                </a>
             </div>
         </div>
     </div>

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -19,7 +19,7 @@
                     <i class="icon-google-plus"></i>
                 </a>
                 <a href="{{ path('social_login', {'provider': 'guildwars'}) }}" class="btn btn-large">
-                    <div>Guild Wars 2</div>
+                    <i class="icon-guildwars2"></i>
                 </a>
             </div>
         </div>

--- a/vendor/hybridauth/Hybrid/Providers/GuildWars.php
+++ b/vendor/hybridauth/Hybrid/Providers/GuildWars.php
@@ -31,11 +31,8 @@ class Hybrid_Providers_GuildWars extends Hybrid_Provider_Model_OAuth2 {
         // refresh tokens if needed
         $this->refreshToken();
 
-        // ask api for user infos
-        $originalHeader = $this->api->curl_header;
-        $this->api->curl_header = array_merge($this->api->curl_header, array("Authorization: Bearer {$this->api->access_token}"));
-        $response = $this->api->api("https://api.guildwars2.com/v2/account");
-        $this->api->curl_header = $originalHeader;
+        // ask api for user info
+        $response = $this->api->api("https://api.guildwars2.com/v2/account", "GET", array(), array("Authorization: Bearer {$this->api->access_token}"));
 
         if (!isset($response->id) || isset($response->error)) {
             throw new Exception("User profile request failed! {$this->providerId} returned an invalid response.", 6);

--- a/vendor/hybridauth/Hybrid/Providers/GuildWars.php
+++ b/vendor/hybridauth/Hybrid/Providers/GuildWars.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: keneanung
+ * Date: 09/03/15
+ * Time: 21:54
+ */
+
+class Hybrid_Providers_GuildWars extends Hybrid_Provider_Model_OAuth2 {
+
+    /**
+     * @var string default scopes
+     */
+    public $scope = "account offline";
+
+    /**
+     * IDp wrappers initializer
+     */
+    function initialize()
+    {
+        parent::initialize();
+
+        // Provider api end-points
+        $this->api->authorize_url  = "https://account.guildwars2.com/oauth2/authorization";
+        $this->api->token_url      = "https://account.guildwars2.com/oauth2/token";
+        $this->api->curl_authenticate_method = "GET";
+    }
+}

--- a/vendor/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/vendor/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -122,7 +122,7 @@ class OAuth2Client
 	/** 
 	* Format and sign an oauth for provider api 
 	*/
-	public function api( $url, $method = "GET", $parameters = array() ) 
+	public function api( $url, $method = "GET", $parameters = array(), $additional_headers = array() )
 	{
 		if ( strrpos($url, 'http://') !== 0 && strrpos($url, 'https://') !== 0 ) {
 			$url = $this->api_base_url . $url;
@@ -132,8 +132,8 @@ class OAuth2Client
 		$response = null;
 
 		switch( $method ){
-			case 'GET'  : $response = $this->request( $url, $parameters, "GET"  ); break; 
-			case 'POST' : $response = $this->request( $url, $parameters, "POST" ); break;
+			case 'GET'  : $response = $this->request( $url, $parameters, "GET", $additional_headers  ); break;
+			case 'POST' : $response = $this->request( $url, $parameters, "POST", $additional_headers ); break;
 		}
 
 		if( $response && $this->decode_json ){
@@ -180,13 +180,14 @@ class OAuth2Client
 			$params[$k] = $v; 
 		}
 
-		$response = $this->request( $this->token_url, $params, $this->curl_authenticate_method );
+		$response = $this->request( $this->token_url, $params, "POST",
+            array( "Content-Type: application/x-www-form-urlencoded" ) );
 		return $this->parseRequestResult( $response );
 	}
 
 	// -- utilities
 
-	private function request( $url, $params=array(), $type="GET" )
+	private function request( $url, $params=array(), $type="GET", $additional_headers = array() )
 	{
 		Hybrid_Logger::info( "Enter OAuth2Client::request( $url )" );
 		Hybrid_Logger::debug( "OAuth2Client::request(). dump request params: ", serialize( $params ) );
@@ -204,7 +205,11 @@ class OAuth2Client
 		curl_setopt($ch, CURLOPT_USERAGENT      , $this->curl_useragent );
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT , $this->curl_connect_time_out );
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER , $this->curl_ssl_verifypeer );
-		curl_setopt($ch, CURLOPT_HTTPHEADER     , $this->curl_header );
+		curl_setopt($ch, CURLOPT_HTTPHEADER     , array_merge($this->curl_header, $additional_headers) );
+
+        curl_setopt($ch, CURLOPT_VERBOSE, true);
+        $verbose = fopen('php://temp', 'rw+');
+        curl_setopt($ch, CURLOPT_STDERR, $verbose);
 
 		if($this->curl_proxy){
 			curl_setopt( $ch, CURLOPT_PROXY        , $this->curl_proxy);
@@ -212,12 +217,18 @@ class OAuth2Client
 
 		if( $type == "POST" ){
 			curl_setopt($ch, CURLOPT_POST, 1); 
-			if($params) curl_setopt( $ch, CURLOPT_POSTFIELDS, $params );
+			if($params) curl_setopt( $ch, CURLOPT_POSTFIELDS, http_build_query($params) );
 		}
 
 		$response = curl_exec($ch);
 		Hybrid_Logger::debug( "OAuth2Client::request(). dump request info: ", serialize( curl_getinfo($ch) ) );
 		Hybrid_Logger::debug( "OAuth2Client::request(). dump request result: ", serialize( $response ) );
+
+        rewind($verbose);
+        $verboseLog = stream_get_contents($verbose);
+        Hybrid_Logger::debug( "OAuth2Client::request(). dump verbose curl: ", $verboseLog );
+        fclose($verbose);
+
 
 		$this->http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 		$this->http_info = array_merge($this->http_info, curl_getinfo($ch));

--- a/vendor/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/vendor/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -180,13 +180,13 @@ class OAuth2Client
 			$params[$k] = $v; 
 		}
 
-		$response = $this->request( $this->token_url, $params, "POST" );
+		$response = $this->request( $this->token_url, $params, $this->curl_authenticate_method );
 		return $this->parseRequestResult( $response );
 	}
 
 	// -- utilities
 
-	private function request( $url, $params=false, $type="GET" )
+	private function request( $url, $params=array(), $type="GET" )
 	{
 		Hybrid_Logger::info( "Enter OAuth2Client::request( $url )" );
 		Hybrid_Logger::debug( "OAuth2Client::request(). dump request params: ", serialize( $params ) );


### PR DESCRIPTION
This adds the OAuth2 authentification by Guild Wars 2 (and changes some defaults
to be more sensible for testing environments).

TODOs:
- get profile information from the GW2 API
- add a nice picture for the login button

This PR serves 2 purposes:
- get early feedback on what I'm doing
- a discussion board for some further things

**Question**: I am debating whether to save the access and refresh tokens with expiry date, because ANet plans features to the API that might be interesting to gw2spidy as well (Bank/character inventory, TP history). Soo...
1. Where to save this information? The users table?
2. How to handle users registered via another OAuth provider or the site directly? Put an "connect with GW2" option somewhere?

That's it for now, if I get more ideas/questions, I'll ask.